### PR TITLE
Fix properties classified as nodes

### DIFF
--- a/factory.js
+++ b/factory.js
@@ -107,7 +107,7 @@ function isNode(tagName, value) {
     )
   }
 
-  return 'value' in value
+  return false
 }
 
 function addChild(nodes, value) {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "xo": "^0.23.0"
   },
   "scripts": {
-    "format": "remark . -qfo && prettier --write '**/*.js' && xo --fix",
+    "format": "remark . -qfo && prettier --write \"**/*.js\" && xo --fix",
     "build-bundle": "browserify . -s hastscript > hastscript.js",
     "build-mangle": "browserify . -s hastscript -p tinyify > hastscript.min.js",
     "build": "npm run build-bundle && npm run build-mangle",

--- a/test.js
+++ b/test.js
@@ -930,6 +930,17 @@ test('hastscript', function(t) {
       'should allow passing multiple child nodes as arguments when there is no properties argument present'
     )
 
+    t.deepEqual(
+      h('div', {type: 'test', value: 'value'}),
+      {
+        type: 'element',
+        tagName: 'div',
+        properties: {type: 'test', value: 'value'},
+        children: []
+      },
+      'should *not* interpret an attribute as children when it has an attribute called "value"'
+    )
+
     st.throws(
       function() {
         h('foo', {}, true)


### PR DESCRIPTION
In the current state, the input (see below) is interpreted as div with a children because there is an assumption that every `node` will has a `value` attribute. This PR will remove this assumption. BTW: The different overloads makes the code very hard to read. I recommend to refactor this in the future.

The change in the script was need to run the format script on windows.

```js
h('div', { type: 'test', value: 'value' })
```
```
{ type: 'element', tagName: 'div', properties: {}, children: [ { type: 'test', value: 'value' } ] }
```
expected
```js
h('div', { type: 'test', value: 'value' })
```
```
{ type: 'element', tagName: 'div', properties: { type: 'test', value: 'value' }, children: [] }
```